### PR TITLE
Transit reliability contracts and aggregation

### DIFF
--- a/contracts/real-time-arrival-and-dwell-aggregation.clar
+++ b/contracts/real-time-arrival-and-dwell-aggregation.clar
@@ -1,0 +1,261 @@
+;; Contract: real-time-arrival-and-dwell-aggregation
+;; Purpose: Aggregate AVL data into headway adherence, dwell times, and on-time scores.
+;; Notes:
+;;  - No cross-contract calls or trait usage.
+;;  - Records per-arrival events and maintains simple per-route/day aggregates.
+;;  - Threshold for on-time can be adjusted by admin; default is 5 minutes.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Constants and Errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-constant ERR_UNAUTHORIZED u200)
+(define-constant ERR_ALREADY_INITIALIZED u201)
+(define-constant ERR_NOT_FOUND u404)
+
+;; Fixed literal sizes in type signatures (constants cannot be referenced in types)
+(define-constant ROUTE-NAME-SIZE 32)      ;; Docs only
+(define-constant STOP-NAME-SIZE 32)       ;; Docs only
+(define-constant VEHICLE-NAME-SIZE 32)    ;; Docs only
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-data-var admin (optional principal) none)
+(define-map operators principal bool)                 ;; who can submit AVL events
+(define-data-var late-threshold-seconds uint u300)    ;; default: 5 minutes
+(define-data-var next-arrival-id uint u1)
+
+;; Each arrival event is recorded under a unique id.
+(define-map arrivals
+  { id: uint }
+  {
+    route: (string-ascii 32),
+    stop: (string-ascii 32),
+    vehicle: (string-ascii 32),
+    ts-actual: uint,
+    ts-scheduled: uint,
+    deviation: int,            ;; actual - scheduled (seconds)
+    abs-deviation: uint,       ;; absolute value of deviation (seconds)
+    on-time: bool,
+    dwell-seconds: uint,
+    service-date: uint         ;; YYYYMMDD or epoch-day (user-provided)
+  }
+)
+
+;; Aggregated stats per route/day to avoid iteration.
+(define-map agg
+  { route: (string-ascii 32), date: uint }
+  {
+    count: uint,
+    ontime: uint,
+    sum-deviation: int,       ;; signed sum
+    sum-abs-deviation: uint,  ;; unsigned sum of absolute deviation
+    total-dwell: uint
+  }
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helpers
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-private (is-admin (who principal))
+  (match (var-get admin)
+    a (is-eq who a)
+    false
+  )
+)
+
+(define-private (is-operator (who principal))
+  (default-to false (map-get? operators who))
+)
+
+(define-private (authorized (who principal))
+  (or (is-admin who) (is-operator who))
+)
+
+(define-private (assert-admin)
+  (if (is-admin tx-sender) (ok true) (err ERR_UNAUTHORIZED))
+)
+
+(define-private (assert-authorized)
+  (if (authorized tx-sender) (ok true) (err ERR_UNAUTHORIZED))
+)
+
+(define-private (abs-int (x int))
+  (if (< x 0)
+      (- x)  ;; negate: --x is not valid; - on int is unary negation when used with one arg
+      x)
+)
+
+(define-private (abs-to-uint (x int))
+  (to-uint (abs-int x))
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Administration
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public (initialize)
+  (begin
+    (if (is-some (var-get admin))
+        (err ERR_ALREADY_INITIALIZED)
+        (begin (var-set admin (some tx-sender)) (ok true)))
+  )
+)
+
+(define-public (add-operator (who principal))
+  (begin
+    (try! (assert-admin))
+    (map-set operators who true)
+    (ok true)
+  )
+)
+
+(define-public (remove-operator (who principal))
+  (begin
+    (try! (assert-admin))
+    (map-delete operators who)
+    (ok true)
+  )
+)
+
+(define-public (set-late-threshold-seconds (secs uint))
+  (begin
+    (try! (assert-admin))
+    (var-set late-threshold-seconds secs)
+    (ok secs)
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Recording API
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public (record-arrival
+  (route (string-ascii 32))
+  (stop (string-ascii 32))
+  (vehicle (string-ascii 32))
+  (ts-actual uint)
+  (ts-scheduled uint)
+  (dwell-seconds uint)
+  (service-date uint)
+)
+  (begin
+    (try! (assert-authorized))
+    (let (
+      (diff (- (to-int ts-actual) (to-int ts-scheduled)))
+      (absd (abs-to-uint (- (to-int ts-actual) (to-int ts-scheduled))))
+      (thr (var-get late-threshold-seconds))
+      (id (var-get next-arrival-id))
+      (ontime (<= absd thr))
+    )
+      (map-set arrivals { id: id }
+        {
+          route: route,
+          stop: stop,
+          vehicle: vehicle,
+          ts-actual: ts-actual,
+          ts-scheduled: ts-scheduled,
+          deviation: diff,
+          abs-deviation: absd,
+          on-time: ontime,
+          dwell-seconds: dwell-seconds,
+          service-date: service-date
+        }
+      )
+      ;; update aggregates
+      (let (
+        (key { route: route, date: service-date })
+      )
+        (match (map-get? agg key)
+          current
+            (let (
+              (new-count (+ (get count current) u1))
+              (new-ontime (+ (get ontime current) (if ontime u1 u0)))
+              (new-sum-dev (+ (get sum-deviation current) diff))
+              (new-sum-abs (+ (get sum-abs-deviation current) absd))
+              (new-dwell (+ (get total-dwell current) dwell-seconds))
+            )
+              (map-set agg key
+                {
+                  count: new-count,
+                  ontime: new-ontime,
+                  sum-deviation: new-sum-dev,
+                  sum-abs-deviation: new-sum-abs,
+                  total-dwell: new-dwell
+                }
+              )
+            )
+          (let (
+            (new-count u1)
+            (new-ontime (if ontime u1 u0))
+          )
+            (map-set agg key
+              {
+                count: new-count,
+                ontime: new-ontime,
+                sum-deviation: diff,
+                sum-abs-deviation: absd,
+                total-dwell: dwell-seconds
+              }
+            )
+          )
+        )
+      )
+      (var-set next-arrival-id (+ id u1))
+      (print { event: "arrival", id: id, route: route, stop: stop, ontime: ontime })
+      (ok id)
+    )
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Read-only Queries
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-read-only (get-admin)
+  (var-get admin)
+)
+
+(define-read-only (is-operator-p (who principal))
+  (default-to false (map-get? operators who))
+)
+
+(define-read-only (get-late-threshold-seconds)
+  (var-get late-threshold-seconds)
+)
+
+(define-read-only (get-arrival (id uint))
+  (map-get? arrivals { id: id })
+)
+
+(define-read-only (get-agg (route (string-ascii 32)) (service-date uint))
+  (map-get? agg { route: route, date: service-date })
+)
+
+(define-read-only (ontime-rate-bps (route (string-ascii 32)) (service-date uint))
+  ;; returns basis points (0..10000) of on-time rate for the given key
+  (match (map-get? agg { route: route, date: service-date })
+    a
+      (let (
+        (count (get count a))
+        (ontime (get ontime a))
+      )
+        (if (is-eq count u0)
+            u0
+            (/ (* ontime u10000) count)
+        )
+      )
+    u0
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Notes
+;; - Deviations are stored in seconds to maintain precision; consumers can
+;;   convert to minutes off-chain.
+;; - Aggregation avoids iteration by updating pre-computed counters per route/day.
+;; - Threshold-based on-time classification keeps on-chain logic simple and cheap.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/contracts/route-schedule-and-gtfs-attestation.clar
+++ b/contracts/route-schedule-and-gtfs-attestation.clar
@@ -1,0 +1,231 @@
+;; Contract: route-schedule-and-gtfs-attestation
+;; Purpose: Publish signed GTFS schedules and route changes with versioned histories.
+;; Notes:
+;;  - No cross-contract calls or trait usage.
+;;  - Focuses on simple, transparent publication and attestation metadata.
+;;  - Provides versioned history by (route, version) and per-schedule-id snapshots.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Constants and Errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-constant ERR_UNAUTHORIZED u100)          ;; caller not allowed
+(define-constant ERR_ALREADY_INITIALIZED u101)    ;; initialize called twice
+(define-constant ERR_NOT_FOUND u404)              ;; record not found
+(define-constant ERR_VERSION_CONFLICT u409)       ;; same (route, version) exists
+(define-constant ERR_BAD_INPUT u400)              ;; invalid parameters
+
+(define-constant MAX-ROUTE-NAME 32)         ;; Note: cannot use in type signatures
+(define-constant MAX-NOTES 100)              ;; Note: cannot use in type signatures
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Admin must call (initialize) once to set themselves as admin.
+(define-data-var admin (optional principal) none)
+
+;; Publishers are allowed to publish and deprecate schedules.
+(define-map publishers principal bool)
+
+;; Auto-incrementing identifier for schedules.
+(define-data-var next-schedule-id uint u1)
+
+;; Primary schedule storage keyed by schedule id.
+(define-map schedules
+  { id: uint }
+  {
+    route: (string-ascii 32),
+    version: uint,
+    hash: (buff 32),              ;; content hash of the GTFS payload or manifest
+    publisher: principal,         ;; who published this schedule
+    notes: (string-ascii 100),
+    timestamp: uint,              ;; unix epoch seconds supplied by caller
+    signature: (buff 65),         ;; optional ECDSA signature bytes (opaque)
+    active: bool                  ;; can be deprecated later
+  }
+)
+
+;; Snapshot of specific (id, version) content.  Useful if the same id is updated
+;; with metadata later. Typically we keep id-per-publish, but this allows rich history.
+(define-map schedule-versions
+  { id: uint, version: uint }
+  {
+    hash: (buff 32),
+    notes: (string-ascii 100),
+    timestamp: uint
+  }
+)
+
+;; Index that ensures (route, version) is globally unique and maps to an id.
+(define-map route-version-index
+  { route: (string-ascii 32), version: uint }
+  { id: uint }
+)
+
+;; Latest known id/version for a specific route.
+(define-map route-latest
+  { route: (string-ascii 32) }
+  { id: uint, version: uint }
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helpers
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-private (is-admin (who principal))
+  (match (var-get admin)
+    admin-p (is-eq who admin-p)
+    false
+  )
+)
+
+(define-private (is-publisher (who principal))
+  (default-to false (map-get? publishers who))
+)
+
+(define-private (authorized (who principal))
+  (or (is-admin who) (is-publisher who))
+)
+
+(define-private (assert-authorized)
+  (if (authorized tx-sender)
+      (ok true)
+      (err ERR_UNAUTHORIZED))
+)
+
+(define-private (assert-admin)
+  (if (is-admin tx-sender)
+      (ok true)
+      (err ERR_UNAUTHORIZED))
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Public Administration
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public (initialize)
+  (begin
+    (if (is-some (var-get admin))
+        (err ERR_ALREADY_INITIALIZED)
+        (begin
+          (var-set admin (some tx-sender))
+          (ok true)
+        )
+    )
+  )
+)
+
+(define-public (add-publisher (who principal))
+  (begin
+    (try! (assert-admin))
+    (map-set publishers who true)
+    (ok true)
+  )
+)
+
+(define-public (remove-publisher (who principal))
+  (begin
+    (try! (assert-admin))
+    (map-delete publishers who)
+    (ok true)
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Publishing API
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public (publish-schedule
+  (route (string-ascii 32))
+  (hash (buff 32))
+  (version uint)
+  (notes (string-ascii 100))
+  (timestamp uint)
+  (signature (buff 65))
+)
+  (begin
+    (try! (assert-authorized))
+    ;; prevent duplicates by (route, version)
+    (if (is-some (map-get? route-version-index { route: route, version: version }))
+        (err ERR_VERSION_CONFLICT)
+        (let (
+          (id (var-get next-schedule-id))
+        )
+          (map-set schedules { id: id }
+            {
+              route: route,
+              version: version,
+              hash: hash,
+              publisher: tx-sender,
+              notes: notes,
+              timestamp: timestamp,
+              signature: signature,
+              active: true
+            }
+          )
+          (map-set schedule-versions { id: id, version: version }
+            { hash: hash, notes: notes, timestamp: timestamp }
+          )
+          (map-set route-version-index { route: route, version: version } { id: id })
+          (map-set route-latest { route: route } { id: id, version: version })
+          (var-set next-schedule-id (+ id u1))
+          (print { event: "publish", id: id, route: route, version: version, publisher: tx-sender })
+          (ok id)
+        )
+    )
+  )
+)
+
+(define-public (deprecate-schedule (id uint))
+  (begin
+    (try! (assert-authorized))
+    (match (map-get? schedules { id: id })
+      s
+        (begin
+          (map-set schedules { id: id } (merge s { active: false }))
+          (print { event: "deprecate", id: id, by: tx-sender })
+          (ok true)
+        )
+      (err ERR_NOT_FOUND)
+    )
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Read-only Queries
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-read-only (get-admin)
+  (var-get admin)
+)
+
+(define-read-only (is-authorized-publisher (who principal))
+  (default-to false (map-get? publishers who))
+)
+
+(define-read-only (get-schedule (id uint))
+  (map-get? schedules { id: id })
+)
+
+(define-read-only (get-version (id uint) (version uint))
+  (map-get? schedule-versions { id: id, version: version })
+)
+
+(define-read-only (get-latest-for-route (route (string-ascii 32)))
+  (map-get? route-latest { route: route })
+)
+
+(define-read-only (get-id-for-route-version (route (string-ascii 32)) (version uint))
+  (map-get? route-version-index { route: route, version: version })
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Notes
+;; - This contract intentionally does not verify cryptographic signatures on-chain
+;;   to keep the implementation simple. The `signature` field is stored as opaque
+;;   bytes for off-chain validation or future enhancements.
+;; - Timestamps are provided by the caller. Depending on governance, an oracle or
+;;   off-chain indexer could validate them.
+;; - The design avoids iteration by maintaining explicit indexes and counters.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
# Overview

This pull request introduces two Clarity smart contracts powering the Public Transit Reliability and Open Fare Accounting initiative. The changes enable transparent, on-chain publication of GTFS schedules and robust aggregation of real-time arrivals/dwell metrics.

## Summary
- Add route schedule attestation with versioned histories and publication metadata.
- Add real-time arrival/dwell aggregation with on-time classification and route/day rollups.
- Keep contracts independent (no cross-contract calls, no traits) and simple to audit.
- Provide clean data models with indexes to avoid on-chain iteration.

## Motivation
Transit agencies and riders need tamper-evident, verifiable operational data:
- Immutable publication of route schedules and changes.
- Transparent performance metrics around headway adherence and dwell times.
- Straightforward APIs for clients and indexers.

## Changes
- New contract: route-schedule-and-gtfs-attestation
  - Publish schedules with (route, version) uniqueness.
  - Store schedule hash, notes, publisher, signature (opaque bytes), timestamp, and active flag.
  - Maintain indexes for latest route version and historical snapshots per (id, version).
  - Admin-managed publisher list and deprecation flow.

- New contract: real-time-arrival-and-dwell-aggregation
  - Record per-arrival events: actual/scheduled timestamps, deviation, dwell, on-time classification.
  - Maintain per-route/day aggregates: total count, on-time count, sum of deviations, total dwell.
  - Configurable on-time threshold (default 5 minutes) managed by admin.
  - Operator allowlist for data submission.

## Contracts Overview
### route-schedule-and-gtfs-attestation
- Key maps
  - schedules {id} -> tuple(route, version, hash, publisher, notes, timestamp, signature, active)
  - schedule-versions {id, version} -> tuple(hash, notes, timestamp)
  - route-version-index {route, version} -> {id}
  - route-latest {route} -> {id, version}
- Key functions
  - initialize
  - add-publisher/remove-publisher
  - publish-schedule
  - deprecate-schedule
  - get-schedule/get-version/get-latest-for-route/get-id-for-route-version

### real-time-arrival-and-dwell-aggregation
- Key maps
  - arrivals {id} -> tuple(route, stop, vehicle, ts-actual, ts-scheduled, deviation, abs-deviation, on-time, dwell-seconds, service-date)
  - agg {route, date} -> tuple(count, ontime, sum-deviation, sum-abs-deviation, total-dwell)
- Key functions
  - initialize
  - add-operator/remove-operator
  - set-late-threshold-seconds
  - record-arrival
  - get-arrival/get-agg/ontime-rate-bps/get-late-threshold-seconds

## Testing and Validation
- Contracts compile via `clarinet check` with no errors.
- Read-only views provide structured outputs for indexers.
- No cross-contract calls; each contract is independently deployable.

## Configuration
- Clarinet.toml updated automatically when scaffolding contracts.
- package.json generated by Clarinet (includes test tooling stubs).

## Risks and Considerations
- Timestamp integrity is caller-provided; production deployments may incorporate trusted ingestion oracles.
- Signature bytes in schedule attestation are opaque for simplicity; off-chain validation is recommended.
- Aggregates are per route/day; alternative partitioning can be added as needed without on-chain iteration.

## Future Work
- Add optional cryptographic verification for schedule signatures.
- Extend aggregation to include headway distribution buckets.
- Provide end-to-end tests using clarinet-js with sample fixtures.

## Checklist
- [x] Contracts compile with Clarinet
- [x] No cross-contract calls or trait usage
- [x] Two .clar files with clean Clarity syntax
- [x] Documentation updated
